### PR TITLE
refactor to use thread safe calls

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -11,27 +11,12 @@ on:
       - README.md
 
 jobs:
-  Build-Test:
+  Version-Comment:
     runs-on: ubuntu-latest
-    container: golang:alpine3.20
-
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Setup blosc library
-        run: |
-          apk add blosc blosc-dev build-base
-      - name: Run Tests
-        run: |
-          CGO_ENABLED=1 go test ./... -coverprofile=coverage.out -covermode=atomic
-      - name: Upload Coverage
-        uses: codecov/codecov-action@v2
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
-          files: ./coverage.out
-
       - name: Calc Semver
         id: semver
         uses: paulhatch/semantic-version@v5.3.0
@@ -48,3 +33,21 @@ jobs:
           repo-token: ${{ secrets.HEADLESS_USER_PAT }}
           repo-token-user-login: "seerai-headless"
           allow-repeats: false
+  Build-Test:
+    runs-on: ubuntu-latest
+    container: golang:alpine3.20
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup blosc library
+        run: |
+          apk add blosc blosc-dev build-base
+      - name: Run Tests
+        run: |
+          CGO_ENABLED=1 go test ./... -coverprofile=coverage.out -covermode=atomic
+      - name: Upload Coverage
+        uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          files: ./coverage.out

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Setup blosc library
         run: |
           apk add blosc blosc-dev build-base

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -32,13 +32,13 @@ jobs:
 
       - name: Calc Semver
         id: semver
-        uses: paulhatch/semantic-version@v4.0.2
+        uses: paulhatch/semantic-version@v5.3.0
         with:
           tag_prefix: "v"
           major_pattern: "(MAJOR)"
           minor_pattern: "(MINOR)"
-          format: "${major}.${minor}.${patch}"
-          short_tags: false
+          version_format: "${major}.${minor}.${patch}"
+          search_commit_body: true
       - uses: mshick/add-pr-comment@v1
         with:
           message: |
@@ -46,6 +46,3 @@ jobs:
           repo-token: ${{ secrets.HEADLESS_USER_PAT }}
           repo-token-user-login: "seerai-headless"
           allow-repeats: false
-      - name: Print Version tag
-        run: |
-          echo ""

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1,54 +1,51 @@
 name: Build Test
 
 on:
-    push:
-        branches: [main]
-        paths-ignore:
-            - README.md
-    pull_request:
-        branches: [main]
-        paths-ignore:
-            - README.md
+  push:
+    branches: [main]
+    paths-ignore:
+      - README.md
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - README.md
 
 jobs:
-    Build-Test:
-        runs-on: ubuntu-latest
-        container: golang:alpine3.20
+  Build-Test:
+    runs-on: ubuntu-latest
+    container: golang:alpine3.20
 
-        steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-go@v5
-              with:
-                  go-version: "1.21"
-            - name: Setup blosc library
-              run: |
-                  sudo apt-get install -y libblosc-dev
-            - name: Run Tests
-              run: |
-                  go test ./... -coverprofile=coverage.out -covermode=atomic
-            - name: Upload Coverage
-              uses: codecov/codecov-action@v2
-              with:
-                  token: ${{ secrets.CODECOV_TOKEN }}
-                  fail_ci_if_error: true
-                  files: ./coverage.out
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup blosc library
+        run: |
+          apk add blosc blosc-dev build-base
+      - name: Run Tests
+        run: |
+          CGO_ENABLED=1 go test ./... -coverprofile=coverage.out -covermode=atomic
+      - name: Upload Coverage
+        uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          files: ./coverage.out
 
-            - name: Calc Semver
-              id: semver
-              uses: paulhatch/semantic-version@v4.0.2
-              with:
-                  tag_prefix: "v"
-                  major_pattern: "(MAJOR)"
-                  minor_pattern: "(MINOR)"
-                  format: "${major}.${minor}.${patch}"
-                  short_tags: false
-            - uses: mshick/add-pr-comment@v1
-              with:
-                  message: |
-                      Next Version to be Released: ${{ steps.semver.outputs.version_tag }}
-                  repo-token: ${{ secrets.HEADLESS_USER_PAT }}
-                  repo-token-user-login: "seerai-headless"
-                  allow-repeats: false
-            - name: Print Version tag
-              run: |
-                  echo ""
+      - name: Calc Semver
+        id: semver
+        uses: paulhatch/semantic-version@v4.0.2
+        with:
+          tag_prefix: "v"
+          major_pattern: "(MAJOR)"
+          minor_pattern: "(MINOR)"
+          format: "${major}.${minor}.${patch}"
+          short_tags: false
+      - uses: mshick/add-pr-comment@v1
+        with:
+          message: |
+            Next Version to be Released: ${{ steps.semver.outputs.version_tag }}
+          repo-token: ${{ secrets.HEADLESS_USER_PAT }}
+          repo-token-user-login: "seerai-headless"
+          allow-repeats: false
+      - name: Print Version tag
+        run: |
+          echo ""

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1,53 +1,54 @@
 name: Build Test
 
 on:
-  push:
-    branches: [main]
-    paths-ignore:
-      - README.md
-  pull_request:
-    branches: [main]
-    paths-ignore:
-      - README.md
+    push:
+        branches: [main]
+        paths-ignore:
+            - README.md
+    pull_request:
+        branches: [main]
+        paths-ignore:
+            - README.md
 
 jobs:
-  Build-Test:
-    runs-on: ubuntu-latest
+    Build-Test:
+        runs-on: ubuntu-latest
+        container: golang:alpine3.20
 
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version: "1.21"
-      - name: Setup blosc library
-        run: |
-          sudo apt-get install -y libblosc-dev
-      - name: Run Tests
-        run: |
-          go test ./... -coverprofile=coverage.out -covermode=atomic
-      - name: Upload Coverage
-        uses: codecov/codecov-action@v2
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
-          files: ./coverage.out
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-go@v5
+              with:
+                  go-version: "1.21"
+            - name: Setup blosc library
+              run: |
+                  sudo apt-get install -y libblosc-dev
+            - name: Run Tests
+              run: |
+                  go test ./... -coverprofile=coverage.out -covermode=atomic
+            - name: Upload Coverage
+              uses: codecov/codecov-action@v2
+              with:
+                  token: ${{ secrets.CODECOV_TOKEN }}
+                  fail_ci_if_error: true
+                  files: ./coverage.out
 
-      - name: Calc Semver
-        id: semver
-        uses: paulhatch/semantic-version@v4.0.2
-        with:
-          tag_prefix: "v"
-          major_pattern: "(MAJOR)"
-          minor_pattern: "(MINOR)"
-          format: "${major}.${minor}.${patch}"
-          short_tags: false
-      - uses: mshick/add-pr-comment@v1
-        with:
-          message: |
-            Next Version to be Released: ${{ steps.semver.outputs.version_tag }}
-          repo-token: ${{ secrets.HEADLESS_USER_PAT }}
-          repo-token-user-login: "seerai-headless"
-          allow-repeats: false
-      - name: Print Version tag
-        run: |
-          echo ""
+            - name: Calc Semver
+              id: semver
+              uses: paulhatch/semantic-version@v4.0.2
+              with:
+                  tag_prefix: "v"
+                  major_pattern: "(MAJOR)"
+                  minor_pattern: "(MINOR)"
+                  format: "${major}.${minor}.${patch}"
+                  short_tags: false
+            - uses: mshick/add-pr-comment@v1
+              with:
+                  message: |
+                      Next Version to be Released: ${{ steps.semver.outputs.version_tag }}
+                  repo-token: ${{ secrets.HEADLESS_USER_PAT }}
+                  repo-token-user-login: "seerai-headless"
+                  allow-repeats: false
+            - name: Print Version tag
+              run: |
+                  echo ""

--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -1,32 +1,32 @@
 name: Test and Release
 
 on:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - README.md
+    push:
+        branches:
+            - main
+        paths-ignore:
+            - README.md
 
 jobs:
-  Test-and-Release:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Increment Semver
-        id: semver
-        uses: paulhatch/semantic-version@v5.3.0
-        with:
-          tag_prefix: "v"
-          major_pattern: "(MAJOR)"
-          minor_pattern: "(MINOR)"
-          format: "${major}.${minor}.${patch}"
-          short_tags: false
-      - name: Create tag
-        id: tag
-        run: |
-          git config user.name github-actions
-          git config user.email gcp-headless@seerai.space
-          git tag ${{ steps.semver.outputs.version_tag }} -m "Beep, Boop. Written by a robot. Beep, Boop."
-          git push --tags
+    Test-and-Release:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+            - name: Increment Semver
+              id: semver
+              uses: paulhatch/semantic-version@v5.3.0
+              with:
+                  tag_prefix: "v"
+                  major_pattern: "(MAJOR)"
+                  minor_pattern: "(MINOR)"
+                  version_format: "${major}.${minor}.${patch}"
+                  search_commit_body: true
+            - name: Create tag
+              id: tag
+              run: |
+                  git config user.name github-actions
+                  git config user.email gcp-headless@seerai.space
+                  git tag ${{ steps.semver.outputs.version_tag }} -m "Beep, Boop. Written by a robot. Beep, Boop."
+                  git push --tags

--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -1,32 +1,32 @@
 name: Test and Release
 
 on:
-    push:
-        branches:
-            - main
-        paths-ignore:
-            - README.md
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - README.md
 
 jobs:
-    Test-and-Release:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-              with:
-                  fetch-depth: 0
-            - name: Increment Semver
-              id: semver
-              uses: paulhatch/semantic-version@v5.3.0
-              with:
-                  tag_prefix: "v"
-                  major_pattern: "(MAJOR)"
-                  minor_pattern: "(MINOR)"
-                  version_format: "${major}.${minor}.${patch}"
-                  search_commit_body: true
-            - name: Create tag
-              id: tag
-              run: |
-                  git config user.name github-actions
-                  git config user.email gcp-headless@seerai.space
-                  git tag ${{ steps.semver.outputs.version_tag }} -m "Beep, Boop. Written by a robot. Beep, Boop."
-                  git push --tags
+  Test-and-Release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Increment Semver
+        id: semver
+        uses: paulhatch/semantic-version@v5.3.0
+        with:
+          tag_prefix: "v"
+          major_pattern: "(MAJOR)"
+          minor_pattern: "(MINOR)"
+          version_format: "${major}.${minor}.${patch}"
+          search_commit_body: true
+      - name: Create tag
+        id: tag
+        run: |
+          git config user.name github-actions
+          git config user.email gcp-headless@seerai.space
+          git tag ${{ steps.semver.outputs.version_tag }} -m "Beep, Boop. Written by a robot. Beep, Boop."
+          git push --tags

--- a/blosc.go
+++ b/blosc.go
@@ -219,9 +219,9 @@ func (c *Context) Compress(slice []byte) ([]byte, error) {
 }
 
 // Decompress takes a byte of compressed data and returns the uncompressed data.
-func (c *Context) Decompress(compressed []byte) []byte {
+func (c *Context) Decompress(compressed []byte) ([]byte, error) {
 	if len(compressed) == 0 {
-		return []byte{}
+		return []byte{}, nil
 	}
 
 	nbytes := C.size_t(0)
@@ -231,6 +231,9 @@ func (c *Context) Decompress(compressed []byte) []byte {
 	C.blosc_cbuffer_sizes(unsafe.Pointer(&compressed[0]), &nbytes, &cbytes, &blksz)
 
 	data := make([]byte, int(nbytes))
-	C.blosc_decompress_ctx(unsafe.Pointer(&compressed[0]), unsafe.Pointer(&data[0]), nbytes, C.int(nThreads))
-	return data
+	ret := C.blosc_decompress_ctx(unsafe.Pointer(&compressed[0]), unsafe.Pointer(&data[0]), nbytes, C.int(nThreads))
+	if ret < 0 {
+		return nil, fmt.Errorf("blosc decompression error: %d", int(ret))
+	}
+	return data, nil
 }

--- a/blosc.go
+++ b/blosc.go
@@ -2,80 +2,223 @@
 package blosc
 
 /*
-#cgo CFLAGS: -O3 -msse2 -D HAVE_LZ4=1
 #cgo LDFLAGS: -lpthread -lblosc
 #include "blosc.h"
-int blosc_set_compressor_wrapper(char* compname) {
-	return blosc_set_compressor(compname);
-}
 */
 import "C"
 import (
-	"fmt"
-	"reflect"
-	"unsafe"
-
 	"errors"
+	"fmt"
+	"runtime"
+	"slices"
+	"strings"
+	"unsafe"
 )
 
-func init() {
-	C.blosc_init()
+type ShuffleType uint
+
+const (
+	NoShuffle         ShuffleType = C.BLOSC_NOSHUFFLE
+	ByteShuffle       ShuffleType = C.BLOSC_SHUFFLE
+	BitShuffle        ShuffleType = C.BLOSC_BITSHUFFLE
+	BitShuffleInvalid ShuffleType = 100
+	// Zarr Version 3 shuffle names
+	NoShuffleStr   = "noshuffle"
+	ByteShuffleStr = "shuffle"
+	BitShuffleStr  = "bitshuffle"
+	InvalidStr     = "invalid"
+)
+
+type CNameType string
+
+const (
+	BloscLZ CNameType = "blosclz"
+	LZ4     CNameType = "lz4"
+	LZ4HC   CNameType = "lz4hc"
+	SNAPPY  CNameType = "snappy"
+	ZLIB    CNameType = "zlib"
+	ZSTD    CNameType = "zstd"
+)
+
+func ValidCompressors() []CNameType {
+	return []CNameType{
+		BloscLZ,
+		LZ4,
+		LZ4HC,
+		SNAPPY,
+		ZLIB,
+		ZSTD,
+	}
 }
 
-// SetCompressor sets the compressor that blosc will use
-func SetCompressor(name string) error {
-	switch name {
-	case "blosclz", "lz4", "lz4hc":
-		break
+func ValidShuffles() []ShuffleType {
+	return []ShuffleType{
+		NoShuffle,
+		ByteShuffle,
+		BitShuffle,
+	}
+}
+
+func (s ShuffleType) String() string {
+	switch s {
+	case NoShuffle:
+		return NoShuffleStr
+	case ByteShuffle:
+		return ByteShuffleStr
+	case BitShuffle:
+		return BitShuffleStr
 	default:
-		return errors.New("only lz4, blosclz, lz4hc are currently supported")
+		return InvalidStr
 	}
-	str := C.CString(name)
-	defer C.free(unsafe.Pointer(str))
-
-	res := C.blosc_set_compressor_wrapper(str)
-	if res < 0 {
-		return fmt.Errorf("invalid compressor '%s'", name)
-	}
-	return nil
 }
 
-// SetBlocksize for the compressor
-func SetBlocksize(blocksize int) {
-	C.blosc_set_blocksize(C.ulong(blocksize))
+func (s *ShuffleType) FromString(str string) {
+	str = strings.ToLower(str)
+	switch str {
+	case "noshuffle":
+		*s = NoShuffle
+	case "shuffle":
+		*s = ByteShuffle
+	case "bitshuffle":
+		*s = BitShuffle
+	default:
+		*s = BitShuffleInvalid
+	}
+}
+
+var nThreads = runtime.NumCPU()
+
+type Context struct {
+	CName     CNameType
+	CLevel    uint
+	Shuffle   ShuffleType
+	BlockSize uint
+	TypeSize  uint
+	nThreads  uint
+}
+
+type ContextOption func(*Context) error
+
+// NewContext creates a new blosc context with the given parameters.
+func WithCompressor(name CNameType) ContextOption {
+	return func(c *Context) error {
+		if !slices.Contains(ValidCompressors(), name) {
+			validCompressors := make([]string, len(ValidCompressors()))
+			for i, v := range ValidCompressors() {
+				validCompressors[i] = string(v)
+			}
+			return fmt.Errorf("invalid compressor name, valid names are: %s", strings.Join(validCompressors, ", "))
+		}
+		c.CName = name
+
+		return nil
+	}
+}
+
+func WithCompressionLevel(level uint) ContextOption {
+	return func(c *Context) error {
+		c.CLevel = level
+		return nil
+	}
+}
+
+func WithShuffle(shuffle ShuffleType) ContextOption {
+	return func(c *Context) error {
+		if shuffle != NoShuffle && shuffle != ByteShuffle && shuffle != BitShuffle {
+			return errors.New("invalid shuffle type")
+		}
+		c.Shuffle = shuffle
+		return nil
+	}
+}
+
+func WithShuffleString(shuffle string) ContextOption {
+	return func(c *Context) error {
+		var s ShuffleType
+		s.FromString(shuffle)
+		if s > BitShuffle {
+			return fmt.Errorf("invalid shuffle type string, must be '%s', '%s', or '%s'", NoShuffleStr, ByteShuffleStr, BitShuffleStr)
+		}
+		c.Shuffle = s
+		return nil
+	}
+}
+
+func WithBlockSize(blocksize uint) ContextOption {
+	return func(c *Context) error {
+		c.BlockSize = blocksize
+		return nil
+	}
+}
+
+func WithTypeSize(typesize uint) ContextOption {
+	return func(c *Context) error {
+		c.TypeSize = typesize
+		return nil
+	}
+}
+
+func WithNThreads(threads uint) ContextOption {
+	return func(c *Context) error {
+		c.nThreads = threads
+		return nil
+	}
+}
+
+func NewContext(opts ...ContextOption) (*Context, error) {
+	c := &Context{
+		CName:     LZ4,
+		CLevel:    5,
+		Shuffle:   NoShuffle,
+		BlockSize: 0,
+		TypeSize:  1,
+		nThreads:  uint(nThreads),
+	}
+	for _, opt := range opts {
+		if err := opt(c); err != nil {
+			return nil, err
+		}
+	}
+
+	return c, nil
 }
 
 // Compress takes a slice of numbers and compresses according to level and shuffle.
-func Compress(level int, shuffle bool, slice interface{}) ([]byte, error) {
-
-	rv := reflect.ValueOf(slice)
-	if rv.Kind() != reflect.Slice {
-		return nil, errors.New("input data must be a slice")
-	}
-	l := rv.Len()
-	if l == 0 {
+func (c *Context) Compress(slice []byte) ([]byte, error) {
+	if len(slice) == 0 {
 		return []byte{}, nil
 	}
 
-	size := int(rv.Index(0).Type().Size())
-	ptr := unsafe.Pointer(rv.Pointer())
-
-	s := 1
-	if !shuffle {
-		s = 0
+	sliceLen := len(slice)
+	size := 1
+	if c.TypeSize > 0 {
+		size = int(c.TypeSize)
 	}
-	compressed := make([]byte, l*size+C.BLOSC_MAX_OVERHEAD)
-	csize := C.blosc_compress(C.int(level), C.int(s), C.size_t(size),
-		C.size_t(l*size),
+	ptr := unsafe.Pointer(&slice[0])
+
+	level := c.CLevel
+
+	compressed := make([]byte, sliceLen*size+C.BLOSC_MAX_OVERHEAD)
+
+	// c str for cname
+	cname := C.CString(string(c.CName))
+	defer C.free(unsafe.Pointer(cname))
+
+	csize := C.blosc_compress_ctx(C.int(level), C.int(c.Shuffle), C.size_t(size),
+		C.size_t(sliceLen),
 		ptr,
 		unsafe.Pointer(&compressed[0]),
-		C.size_t(len(compressed)))
+		C.size_t(len(compressed)),
+		cname,
+		C.size_t(c.BlockSize),
+		C.int(nThreads),
+	)
 
 	return compressed[:csize], nil
 }
 
 // Decompress takes a byte of compressed data and returns the uncompressed data.
-func Decompress(compressed []byte) []byte {
+func (c *Context) Decompress(compressed []byte) []byte {
 	if len(compressed) == 0 {
 		return []byte{}
 	}
@@ -87,6 +230,6 @@ func Decompress(compressed []byte) []byte {
 	C.blosc_cbuffer_sizes(unsafe.Pointer(&compressed[0]), &nbytes, &cbytes, &blksz)
 
 	data := make([]byte, int(nbytes))
-	C.blosc_decompress(unsafe.Pointer(&compressed[0]), unsafe.Pointer(&data[0]), nbytes)
+	C.blosc_decompress_ctx(unsafe.Pointer(&compressed[0]), unsafe.Pointer(&data[0]), nbytes, C.int(nThreads))
 	return data
 }

--- a/blosc.go
+++ b/blosc.go
@@ -7,7 +7,6 @@ package blosc
 */
 import "C"
 import (
-	"errors"
 	"fmt"
 	"runtime"
 	"slices"
@@ -87,11 +86,11 @@ func (s *ShuffleType) FromString(str string) {
 var nThreads = runtime.NumCPU()
 
 type Context struct {
-	CName     CNameType
-	CLevel    uint
-	Shuffle   ShuffleType
-	BlockSize uint
-	TypeSize  uint
+	cname     CNameType
+	clevel    uint
+	shuffle   ShuffleType
+	blockSize uint
+	typeSize  uint
 	nThreads  uint
 }
 
@@ -107,7 +106,7 @@ func WithCompressor(name CNameType) ContextOption {
 			}
 			return fmt.Errorf("invalid compressor name, valid names are: %s", strings.Join(validCompressors, ", "))
 		}
-		c.CName = name
+		c.cname = name
 
 		return nil
 	}
@@ -115,7 +114,7 @@ func WithCompressor(name CNameType) ContextOption {
 
 func WithCompressionLevel(level uint) ContextOption {
 	return func(c *Context) error {
-		c.CLevel = level
+		c.clevel = level
 		return nil
 	}
 }
@@ -123,9 +122,9 @@ func WithCompressionLevel(level uint) ContextOption {
 func WithShuffle(shuffle ShuffleType) ContextOption {
 	return func(c *Context) error {
 		if shuffle != NoShuffle && shuffle != ByteShuffle && shuffle != BitShuffle {
-			return errors.New("invalid shuffle type")
+			return fmt.Errorf("invalid shuffle type %d", shuffle)
 		}
-		c.Shuffle = shuffle
+		c.shuffle = shuffle
 		return nil
 	}
 }
@@ -134,24 +133,24 @@ func WithShuffleString(shuffle string) ContextOption {
 	return func(c *Context) error {
 		var s ShuffleType
 		s.FromString(shuffle)
-		if s > BitShuffle {
+		if s == BitShuffleInvalid {
 			return fmt.Errorf("invalid shuffle type string, must be '%s', '%s', or '%s'", NoShuffleStr, ByteShuffleStr, BitShuffleStr)
 		}
-		c.Shuffle = s
+		c.shuffle = s
 		return nil
 	}
 }
 
 func WithBlockSize(blocksize uint) ContextOption {
 	return func(c *Context) error {
-		c.BlockSize = blocksize
+		c.blockSize = blocksize
 		return nil
 	}
 }
 
 func WithTypeSize(typesize uint) ContextOption {
 	return func(c *Context) error {
-		c.TypeSize = typesize
+		c.typeSize = typesize
 		return nil
 	}
 }
@@ -165,11 +164,11 @@ func WithNThreads(threads uint) ContextOption {
 
 func NewContext(opts ...ContextOption) (*Context, error) {
 	c := &Context{
-		CName:     LZ4,
-		CLevel:    5,
-		Shuffle:   NoShuffle,
-		BlockSize: 0,
-		TypeSize:  1,
+		cname:     LZ4,
+		clevel:    5,
+		shuffle:   NoShuffle,
+		blockSize: 0,
+		typeSize:  1,
 		nThreads:  uint(nThreads),
 	}
 	for _, opt := range opts {
@@ -189,30 +188,30 @@ func (c *Context) Compress(slice []byte) ([]byte, error) {
 
 	sliceLen := len(slice)
 	size := 1
-	if c.TypeSize > 0 {
-		size = int(c.TypeSize)
+	if c.typeSize > 0 {
+		size = int(c.typeSize)
 	}
 	ptr := unsafe.Pointer(&slice[0])
 
-	level := c.CLevel
+	level := c.clevel
 
 	compressed := make([]byte, sliceLen*size+C.BLOSC_MAX_OVERHEAD)
 
 	// c str for cname
-	cname := C.CString(string(c.CName))
+	cname := C.CString(string(c.cname))
 	defer C.free(unsafe.Pointer(cname))
 
-	csize := C.blosc_compress_ctx(C.int(level), C.int(c.Shuffle), C.size_t(size),
+	csize := C.blosc_compress_ctx(C.int(level), C.int(c.shuffle), C.size_t(size),
 		C.size_t(sliceLen),
 		ptr,
 		unsafe.Pointer(&compressed[0]),
 		C.size_t(len(compressed)),
 		cname,
-		C.size_t(c.BlockSize),
+		C.size_t(c.blockSize),
 		C.int(nThreads),
 	)
 	if csize < 0 {
-		return nil, fmt.Errorf("blosc compression error while using compressor %s: %d", c.CName, int(csize))
+		return nil, fmt.Errorf("blosc compression error while using compressor %s: %d", c.cname, int(csize))
 	}
 
 	return compressed[:csize], nil

--- a/blosc.go
+++ b/blosc.go
@@ -35,7 +35,6 @@ const (
 	BloscLZ CNameType = "blosclz"
 	LZ4     CNameType = "lz4"
 	LZ4HC   CNameType = "lz4hc"
-	SNAPPY  CNameType = "snappy"
 	ZLIB    CNameType = "zlib"
 	ZSTD    CNameType = "zstd"
 )
@@ -45,7 +44,6 @@ func ValidCompressors() []CNameType {
 		BloscLZ,
 		LZ4,
 		LZ4HC,
-		SNAPPY,
 		ZLIB,
 		ZSTD,
 	}
@@ -213,6 +211,9 @@ func (c *Context) Compress(slice []byte) ([]byte, error) {
 		C.size_t(c.BlockSize),
 		C.int(nThreads),
 	)
+	if csize < 0 {
+		return nil, fmt.Errorf("blosc compression error while using compressor %s: %d", c.CName, int(csize))
+	}
 
 	return compressed[:csize], nil
 }

--- a/blosc_test.go
+++ b/blosc_test.go
@@ -1,8 +1,9 @@
 package blosc_test
 
 import (
+	"bytes"
+	"encoding/binary"
 	"testing"
-	"unsafe"
 
 	blosc "github.com/seerai/go-blosc"
 	"github.com/stretchr/testify/require"
@@ -10,33 +11,128 @@ import (
 
 func TestRoundTrip(t *testing.T) {
 
-	buf := make([]int64, 10000)
-	for i := 0; i < len(buf); i++ {
-		buf[i] = int64(112)
+	ints := make([]int64, 10000)
+	for i := 0; i < len(ints); i++ {
+		ints[i] = int64(112)
 	}
 
-	err := blosc.SetCompressor("lz4")
+	// convert to byte slice
+	buf := &bytes.Buffer{}
+	err := binary.Write(buf, binary.LittleEndian, ints)
 	require.NoError(t, err)
 
-	cmp, err := blosc.Compress(1, true, buf)
+	c, err := blosc.NewContext(
+		blosc.WithCompressor("lz4"),
+		blosc.WithCompressionLevel(9),
+		blosc.WithShuffleString("bitshuffle"),
+		blosc.WithShuffle(blosc.BitShuffle),
+		blosc.WithBlockSize(100),
+		blosc.WithTypeSize(8),
+		blosc.WithNThreads(2),
+	)
 	require.NoError(t, err)
-	dec := blosc.Decompress(cmp)
-	require.Equal(t, len(buf)*int(unsafe.Sizeof(buf[0])), len(dec))
 
-	obuf := (*(*[1 << 32]int64)(unsafe.Pointer(&dec[0])))[:len(dec)/int(unsafe.Sizeof(buf[0]))]
-	for i, o := range obuf {
-		require.Equal(t, buf[i], o)
+	cmp, err := c.Compress(buf.Bytes())
+	require.NoError(t, err)
+	dec := c.Decompress(cmp)
+	require.Equal(t, len(buf.Bytes()), len(dec))
+
+	for _, cName := range blosc.ValidCompressors() {
+		c, err := blosc.NewContext(
+			blosc.WithCompressor(cName),
+		)
+		require.NoError(t, err)
+
+		cmp, err := c.Compress(buf.Bytes())
+		require.NoError(t, err)
+		dec := c.Decompress(cmp)
+		require.Equal(t, len(buf.Bytes()), len(dec))
 	}
 
+	// for each shuffle type
+	for _, shuffle := range blosc.ValidShuffles() {
+		c, err := blosc.NewContext(
+			blosc.WithShuffle(shuffle),
+		)
+		require.NoError(t, err)
+
+		cmp, err := c.Compress(buf.Bytes())
+		require.NoError(t, err)
+		dec := c.Decompress(cmp)
+		require.Equal(t, len(buf.Bytes()), len(dec))
+	}
+
+	// Invalid shuffle string
+	_, err = blosc.NewContext(
+		blosc.WithShuffleString("invalidshuffle"),
+	)
+	require.Error(t, err)
+
+	// Invalid shuffle type
+	_, err = blosc.NewContext(
+		blosc.WithShuffle(blosc.ShuffleType(100)),
+	)
+	require.Error(t, err)
+
+	// Invalid compressor
+	_, err = blosc.NewContext(
+		blosc.WithCompressor("invalidcompressor"),
+	)
+	require.Error(t, err)
+}
+
+func TestShuffleTypes(t *testing.T) {
+	shuffles := blosc.ValidShuffles()
+	require.Equal(t, 3, len(shuffles))
+	require.Contains(t, shuffles, blosc.NoShuffle)
+	require.Contains(t, shuffles, blosc.ByteShuffle)
+	require.Contains(t, shuffles, blosc.BitShuffle)
+
+	// test string conversion
+	require.Equal(t, blosc.NoShuffleStr, blosc.NoShuffle.String())
+	require.Equal(t, blosc.ByteShuffleStr, blosc.ByteShuffle.String())
+	require.Equal(t, blosc.BitShuffleStr, blosc.BitShuffle.String())
+
+	// test FromString
+	var s blosc.ShuffleType
+	s.FromString("nosHUffle")
+	require.Equal(t, blosc.NoShuffle, s)
+	s.FromString("SHUffle")
+	require.Equal(t, blosc.ByteShuffle, s)
+	s.FromString("bitSHUffle")
+	require.Equal(t, blosc.BitShuffle, s)
+
+	s = blosc.ShuffleType(101)
+	require.Equal(t, "invalid", s.String())
+}
+
+func TestRoundTripDefaults(t *testing.T) {
+
+	ints := make([]int64, 10000)
+	for i := 0; i < len(ints); i++ {
+		ints[i] = int64(112)
+	}
+
+	// convert to byte slice
+	buf := &bytes.Buffer{}
+	err := binary.Write(buf, binary.LittleEndian, ints)
+	require.NoError(t, err)
+
+	c, err := blosc.NewContext()
+	require.NoError(t, err)
+
+	cmp, err := c.Compress(buf.Bytes())
+	require.NoError(t, err)
+	dec := c.Decompress(cmp)
+	require.Equal(t, len(buf.Bytes()), len(dec))
 }
 
 func TestEmpty(t *testing.T) {
 	var b []byte
-	err := blosc.SetCompressor("lz4")
+	c, err := blosc.NewContext()
 	require.NoError(t, err)
-
-	cmp, err := blosc.Compress(1, true, b)
+	cmp, err := c.Compress(b)
 	require.NoError(t, err)
-	dec := blosc.Decompress(cmp)
+	dec := c.Decompress(cmp)
 	require.Equal(t, 0, len(dec))
 }

--- a/blosc_test.go
+++ b/blosc_test.go
@@ -34,7 +34,8 @@ func TestRoundTrip(t *testing.T) {
 
 	cmp, err := c.Compress(buf.Bytes())
 	require.NoError(t, err)
-	dec := c.Decompress(cmp)
+	dec, err := c.Decompress(cmp)
+	require.NoError(t, err)
 	require.Equal(t, len(buf.Bytes()), len(dec))
 
 	for _, cName := range blosc.ValidCompressors() {
@@ -45,7 +46,8 @@ func TestRoundTrip(t *testing.T) {
 
 		cmp, err := c.Compress(buf.Bytes())
 		require.NoError(t, err)
-		dec := c.Decompress(cmp)
+		dec, err := c.Decompress(cmp)
+		require.NoError(t, err)
 		require.Equal(t, len(buf.Bytes()), len(dec))
 	}
 
@@ -58,7 +60,8 @@ func TestRoundTrip(t *testing.T) {
 
 		cmp, err := c.Compress(buf.Bytes())
 		require.NoError(t, err)
-		dec := c.Decompress(cmp)
+		dec, err := c.Decompress(cmp)
+		require.NoError(t, err)
 		require.Equal(t, len(buf.Bytes()), len(dec))
 	}
 
@@ -123,7 +126,8 @@ func TestRoundTripDefaults(t *testing.T) {
 
 	cmp, err := c.Compress(buf.Bytes())
 	require.NoError(t, err)
-	dec := c.Decompress(cmp)
+	dec, err := c.Decompress(cmp)
+	require.NoError(t, err)
 	require.Equal(t, len(buf.Bytes()), len(dec))
 }
 
@@ -133,6 +137,7 @@ func TestEmpty(t *testing.T) {
 	require.NoError(t, err)
 	cmp, err := c.Compress(b)
 	require.NoError(t, err)
-	dec := c.Decompress(cmp)
+	dec, err := c.Decompress(cmp)
+	require.NoError(t, err)
 	require.Equal(t, 0, len(dec))
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/seerai/go-blosc
 
-go 1.18
+go 1.24.0
 
 require github.com/stretchr/testify v1.9.0
 


### PR DESCRIPTION
This refactors the library to use thread safe calls instead of the global context. Also cleans up the API to make it a bit more ergonomic and idiomatic as well as adds some convenience methods around Zarr's usage of blosc.